### PR TITLE
fix: use buffer type instead of pointer

### DIFF
--- a/ts/plugin.ts
+++ b/ts/plugin.ts
@@ -12,7 +12,7 @@ const library = await Plug.prepare({
   url: NOTIFY_PLUGIN_URL,
   policy: POLICY,
 }, {
-  notify_send: { parameters: ["pointer", "usize"], result: "pointer" },
+  notify_send: { parameters: ["buffer", "usize"], result: "buffer" },
 });
 
 function readPointer(v: any): Uint8Array {


### PR DESCRIPTION
Breaking change in deno 1.25.

Deno [specialized buffer type](https://github.com/denoland/deno/pull/15518). Which broke things. This fixes that.